### PR TITLE
feat/use-bcrypt

### DIFF
--- a/src/tm-server/package-lock.json
+++ b/src/tm-server/package-lock.json
@@ -8,8 +8,10 @@
       "name": "server",
       "version": "0.0.1",
       "dependencies": {
+        "@types/bcryptjs": "^2.4.2",
         "apollo-server-express": "^2.21.1",
         "argon2": "^0.27.2",
+        "bcryptjs": "^2.4.3",
         "class-validator": "^0.13.1",
         "connect-redis": "^6.0.0",
         "cookie-parser": "^1.4.5",
@@ -363,6 +365,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.2.tgz",
+      "integrity": "sha512-LiMQ6EOPob/4yUL66SZzu6Yh77cbzJFYll+ZfaPiPPFswtIlA/Fs1MzdKYA7JApHU49zQTbJGX3PDmCpIdDBRQ=="
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.0",
@@ -1543,6 +1550,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -7601,6 +7613,11 @@
         "@types/node": "*"
       }
     },
+    "@types/bcryptjs": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.2.tgz",
+      "integrity": "sha512-LiMQ6EOPob/4yUL66SZzu6Yh77cbzJFYll+ZfaPiPPFswtIlA/Fs1MzdKYA7JApHU49zQTbJGX3PDmCpIdDBRQ=="
+    },
     "@types/body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
@@ -8498,6 +8515,11 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
     },
     "binary-extensions": {
       "version": "2.2.0",

--- a/src/tm-server/package.json
+++ b/src/tm-server/package.json
@@ -26,8 +26,9 @@
     "typescript": "^4.3.2"
   },
   "dependencies": {
+    "@types/bcryptjs": "^2.4.2",
     "apollo-server-express": "^2.21.1",
-    "argon2": "^0.27.2",
+    "bcryptjs": "^2.4.3",
     "class-validator": "^0.13.1",
     "connect-redis": "^6.0.0",
     "cookie-parser": "^1.4.5",

--- a/src/tm-server/src/resolvers/user.ts
+++ b/src/tm-server/src/resolvers/user.ts
@@ -1,6 +1,6 @@
 import 'dotenv-safe/config';
 import { v4 } from 'uuid';
-import argon2 from 'argon2';
+import bcrypt from 'bcryptjs';
 import {
   Arg,
   Ctx,
@@ -93,7 +93,7 @@ export class UserResolver {
     await User.update(
       { id: userIdNum },
       {
-        password: await argon2.hash(newPassword),
+        password: await bcrypt.hash(newPassword, 12),
       },
     );
     await redis.del(key);
@@ -144,7 +144,7 @@ export class UserResolver {
     if (errors) {
       return { errors };
     }
-    const hashedPassword = await argon2.hash(options.password);
+    const hashedPassword = await bcrypt.hash(options.password, 12);
     let user;
     try {
       const result = await getConnection()
@@ -195,7 +195,7 @@ export class UserResolver {
         ],
       };
     }
-    const valid = await argon2.verify(user.password, password);
+    const valid = await bcrypt.compare(user.password, password);
     if (!valid) {
       return {
         errors: [


### PR DESCRIPTION
Unfortunately, argon2 seems to break when the backend project is built in a docker image (with Ubuntu 20.04 as the host). More about the issue: https://github.com/ranisalt/node-argon2/issues/244. In order to get around this the server will now use bcryptjs